### PR TITLE
Modeling With Structs

### DIFF
--- a/elixir-otp-pragstudio/README.md
+++ b/elixir-otp-pragstudio/README.md
@@ -77,7 +77,24 @@ Journey of learning guided by the [Developing With Elixir/OTP] video course.
 
   - `__DIR__` versus `File.cwd!` (use `h […]` if a reminder is needed)
 
-- [ ] 12. Modeling With Structs
+- [x] 12. Modeling With Structs
+
+  - `Map`s are generic data structures.
+    - they support arbitrary keys and values.
+  - `Struct`s make implied constraints explicit (think types)
+    - a `Struct` is a "special `Map`"
+      - fix set of fields
+      - default values
+      - constraints are checked at _compile-time_: validate to support only valid fields
+    - one Struct per module, inheriting the module's name
+    - create (initialize?) with supplied values to override the defaults
+    - _stricter access_ when compared to maps: dot-notation only
+    - pattern matching applies
+    - specific _type_ of `Map`
+    - provides _type safety_
+    - makes application code more _robust_
+    - **Use:** model _entities_ of our _domain_
+
 - [ ] 13. Matching Heads and Tails
 - [ ] 14. Recursion
 - [ ] 15. Slicing and Dicing with Enum

--- a/elixir-otp-pragstudio/servy/lib/servy/conv.ex
+++ b/elixir-otp-pragstudio/servy/lib/servy/conv.ex
@@ -1,0 +1,20 @@
+defmodule Servy.Conv do
+  defstruct method: "", path: "", resp_body: "", status: nil
+
+  def full_status(%Servy.Conv{status: status}) do
+    "#{status} #{status_reason(status)}"
+  end
+
+  defp status_reason(code) do
+    codes = %{
+      200 => "OK",
+      201 => "Created",
+      401 => "Unauthorized",
+      403 => "Forbidden",
+      404 => "Not Found",
+      500 => "Internal Server Error"
+    }
+
+    codes[code]
+  end
+end

--- a/elixir-otp-pragstudio/servy/lib/servy/handler.ex
+++ b/elixir-otp-pragstudio/servy/lib/servy/handler.ex
@@ -6,13 +6,15 @@ defmodule Servy.Handler do
     * `conv` represents the "conversation" between the browser and our server.
   """
 
+  alias Servy.Conv
+
   import Servy.FileHandler, only: [handle_file: 2]
   import Servy.Parser, only: [parse: 1]
   import Servy.Plugins, only: [rewrite_path: 1, track: 1]
 
   require Logger
 
-  @pages_path Path.expand("pages", File.cwd!)
+  @pages_path Path.expand("pages", File.cwd!())
 
   @doc "Transforms a request into a response."
   def handle(request) do
@@ -27,27 +29,27 @@ defmodule Servy.Handler do
   @doc """
   Add the response body and status code to the `conv` map.
   """
-  def route(%{method: "GET", path: "/wildthings"} = conv),
+  def route(%Conv{method: "GET", path: "/wildthings"} = conv),
     do: %{conv | status: 200, resp_body: "Bears, Lions, Tigers"}
 
-  def route(%{method: "GET", path: "/bears"} = conv),
+  def route(%Conv{method: "GET", path: "/bears"} = conv),
     do: %{conv | status: 200, resp_body: "Teddy, Smokey, Paddington"}
 
-  def route(%{method: "GET", path: "/bears/new"} = conv) do
+  def route(%Conv{method: "GET", path: "/bears/new"} = conv) do
     # TODO Revisit semantic duplication relative to
-    #      route(%{method: "GET", path: "/pages/" <> static_page_slug} = conv)
+    #      route(%Conv{method: "GET", path: "/pages/" <> static_page_slug} = conv)
     @pages_path
     |> Path.join("form.html")
     |> File.read()
     |> handle_file(conv)
   end
 
-  def route(%{method: "GET", path: "/bears/" <> id} = conv),
+  def route(%Conv{method: "GET", path: "/bears/" <> id} = conv),
     do: %{conv | status: 200, resp_body: "Bear #{id}"}
 
-  def route(%{method: "GET", path: "/pages/" <> static_page_slug} = conv) do
+  def route(%Conv{method: "GET", path: "/pages/" <> static_page_slug} = conv) do
     # TODO Revisit semantic duplication relative to
-    #      route(%{method: "GET", path: "/bears/new"} = conv)
+    #      route(%Conv{method: "GET", path: "/bears/new"} = conv)
     @pages_path
     |> Path.join("#{static_page_slug}.html")
     |> File.read()
@@ -64,34 +66,21 @@ defmodule Servy.Handler do
     end
   end
 
-  def route(%{method: "DELETE", path: "/bears/" <> _id} = conv),
+  def route(%Conv{method: "DELETE", path: "/bears/" <> _id} = conv),
     do: %{conv | status: 403, resp_body: "Bears can never be deleted!"}
 
-  def route(%{path: path} = conv), do: %{conv | status: 404, resp_body: "No #{path} here!"}
+  def route(%Conv{path: path} = conv), do: %{conv | status: 404, resp_body: "No #{path} here!"}
 
   @doc """
   Transform the `conv` map into a valid HTTP response string.
   """
-  def format_response(%{resp_body: resp_body, status: status} = _conv) do
+  def format_response(%Conv{resp_body: resp_body} = conv) do
     """
-    HTTP/1.1 #{status} #{status_reason(status)}
+    HTTP/1.1 #{Conv.full_status(conv)}
     Content-Type: text/html
     Content-Length: #{byte_size(resp_body)}
 
     #{resp_body}
     """
-  end
-
-  defp status_reason(code) do
-    codes = %{
-      200 => "OK",
-      201 => "Created",
-      401 => "Unauthorized",
-      403 => "Forbidden",
-      404 => "Not Found",
-      500 => "Internal Server Error"
-    }
-
-    codes[code]
   end
 end

--- a/elixir-otp-pragstudio/servy/lib/servy/parser.ex
+++ b/elixir-otp-pragstudio/servy/lib/servy/parser.ex
@@ -3,6 +3,8 @@ defmodule Servy.Parser do
   Parses HTTP requests.
   """
 
+  alias Servy.Conv
+
   @doc """
   Transform a HTTP request string into a map.
   """
@@ -13,11 +15,9 @@ defmodule Servy.Parser do
       |> List.first()
       |> String.split()
 
-    %{
+    %Conv{
       method: method,
-      path: path,
-      resp_body: "",
-      status: nil
+      path: path
     }
   end
 end

--- a/elixir-otp-pragstudio/servy/lib/servy/plugins.ex
+++ b/elixir-otp-pragstudio/servy/lib/servy/plugins.ex
@@ -3,36 +3,38 @@ defmodule Servy.Plugins do
   General use plugin functions.
   """
 
+  alias Servy.Conv
+
   require Logger
 
   @doc """
   Rewrite (re-route?) paths to make them prettier or to juice up a page's SEO.
   """
-  def rewrite_path(%{path: "/wildlife"} = conv) do
+  def rewrite_path(%Conv{path: "/wildlife"} = conv) do
     %{conv | path: "/wildthings"}
   end
 
-  def rewrite_path(%{path: path} = conv) do
+  def rewrite_path(%Conv{path: path} = conv) do
     regex = ~r{\/(?<entity>\w+)\?id=(?<id>\d+)}
     captures = Regex.named_captures(regex, path)
     rewrite_path_captures(conv, captures)
   end
 
-  def rewrite_path(conv), do: conv
+  def rewrite_path(%Conv{} = conv), do: conv
 
   # TODO Intentional about keeping these private function clauses close to the
   # call site. For now.
-  defp rewrite_path_captures(conv, %{"entity" => entity, "id" => id}) do
+  defp rewrite_path_captures(%Conv{} = conv, %{"entity" => entity, "id" => id}) do
     %{conv | path: "/#{entity}/#{id}"}
   end
 
-  defp rewrite_path_captures(conv, nil), do: conv
+  defp rewrite_path_captures(%Conv{} = conv, nil), do: conv
 
   @doc "Logs 404 requests."
-  def track(%{status: 404, path: path} = conv) do
+  def track(%Conv{status: 404, path: path} = conv) do
     Logger.warn("#{path} is on the loose!")
     conv
   end
 
-  def track(conv), do: conv
+  def track(%Conv{} = conv), do: conv
 end

--- a/elixir-otp-pragstudio/servy/test/servy/handler_test.exs
+++ b/elixir-otp-pragstudio/servy/test/servy/handler_test.exs
@@ -1,6 +1,8 @@
 defmodule Servy.HandlerTest do
   use ExUnit.Case
 
+  alias Servy.Conv
+
   describe "handle/1" do
     test "handles a request to GET /wildthings" do
       expected_response = """
@@ -122,14 +124,14 @@ defmodule Servy.HandlerTest do
 
   describe "route/1" do
     test "routes a conversation" do
-      conversation = %{
+      conversation = %Conv{
         method: "GET",
         path: "/wildthings",
         resp_body: "",
         status: 200
       }
 
-      expected_response = %{conversation | resp_body: "Bears, Lions, Tigers"}
+      expected_response = %Conv{conversation | resp_body: "Bears, Lions, Tigers"}
 
       actual_response =
         conversation
@@ -139,14 +141,14 @@ defmodule Servy.HandlerTest do
     end
 
     test "serves a static file" do
-      conversation = %{
+      conversation = %Conv{
         method: "GET",
         path: "/pages/about",
         resp_body: "",
         status: 200
       }
 
-      expected_response = %{
+      expected_response = %Conv{
         conversation
         | resp_body: """
           <h1>Clark's Wildthings Refuge</h1>
@@ -170,7 +172,7 @@ defmodule Servy.HandlerTest do
 
   describe "format_response/1" do
     test "formats a conversation as a valid HTTP response string" do
-      conversation = %{
+      conversation = %Conv{
         method: "GET",
         path: "/wildthings",
         resp_body: "Bears, Lions, Tigers",

--- a/elixir-otp-pragstudio/servy/test/servy/parser_test.exs
+++ b/elixir-otp-pragstudio/servy/test/servy/parser_test.exs
@@ -1,9 +1,11 @@
 defmodule Servy.ParserTest do
   use ExUnit.Case
 
+  alias Servy.Conv
+
   describe "parse/1" do
     test "parses a request" do
-      expected_response = %{
+      expected_response = %Conv{
         method: "GET",
         path: "/wildthings",
         resp_body: "",

--- a/elixir-otp-pragstudio/servy/test/servy/plugins_test.exs
+++ b/elixir-otp-pragstudio/servy/test/servy/plugins_test.exs
@@ -1,16 +1,18 @@
 defmodule Servy.PluginsTest do
   use ExUnit.Case
 
+  alias Servy.Conv
+
   describe "rewrite_path/1" do
     test "rewrites requests for /wildlife to /wildthings" do
-      conversation = %{
+      conversation = %Conv{
         method: "GET",
         path: "/wildlife",
         resp_body: "",
         status: nil
       }
 
-      expected_response = %{
+      expected_response = %Conv{
         method: "GET",
         path: "/wildthings",
         resp_body: "",
@@ -25,14 +27,14 @@ defmodule Servy.PluginsTest do
     end
 
     test "rewrites requests for /bears?id=1 to /bears/1" do
-      conversation = %{
+      conversation = %Conv{
         method: "GET",
         path: "/bears?id=1",
         resp_body: "",
         status: nil
       }
 
-      expected_response = %{
+      expected_response = %Conv{
         method: "GET",
         path: "/bears/1",
         resp_body: "",


### PR DESCRIPTION
Model _entities_ of our _domain_, all the while adding type safety.

  - `Map`s are generic data structures.
    - they support arbitrary keys and values.
  - `Struct`s make implied constraints explicit (think types)
    - a `Struct` is a "special `Map`"
      - fix set of fields
      - default values
      - constraints are checked at _compile-time_: validate to support only valid fields
    - one Struct per module, inheriting the module's name
    - create (initialize?) with supplied values to override the defaults
    - _stricter access_ when compared to maps: dot-notation only
    - pattern matching applies
    - specific _type_ of `Map`
    - provides _type safety_
    - makes application code more _robust_
    - **Use:** model _entities_ of our _domain_